### PR TITLE
Make compatible with Adobe ColdFusion 2016

### DIFF
--- a/lib/Cuid2.cfc
+++ b/lib/Cuid2.cfc
@@ -176,13 +176,12 @@ component
 		// variable-length string.
 		var result = BigIntegerClass
 			.init( bytes )
-			.toString( 36 )
-			// NOTE: In the JavaScript version of CUID2, Eric Elliott removes the first
-			// two letters of the hash. His note says that the first two letters bias the
-			// generated CUIDs towards a narrower set of values. Anecdotally, I do see the
-			// dash ("-") showing up a lot unless I remove the first 2 characters as well.
-			.right( -2 )
-		;
+			.toString( 36 );
+		// NOTE: In the JavaScript version of CUID2, Eric Elliott removes the first
+		// two letters of the hash. His note says that the first two letters bias the
+		// generated CUIDs towards a narrower set of values. Anecdotally, I do see the
+		// dash ("-") showing up a lot unless I remove the first 2 characters as well.
+		result = right(result, len(result)-2);
 
 		return( result );
 
@@ -253,7 +252,7 @@ component
 
 		}
 
-		return( value )
+		return( value );
 
 	}
 


### PR DESCRIPTION
negative right() values aren't supported w/CF2016. Missing ending semicolon.